### PR TITLE
Increase minimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@
 #  knowledge of the CeCILL and CeCILL-C licenses and that you accept its terms.
 #
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 cmake_policy(SET CMP0046 OLD)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)


### PR DESCRIPTION
Commit dde837d introduced commands (file(TOUCH) for example) which are supported only by quite recent versions of cmake, but unfortunately the minimum required version wasn't adjusted. Do that now.